### PR TITLE
Makie: Add an extension for plotting with Makie

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,11 +12,19 @@ Geodesics = "6aaf26a4-c633-11e8-35ae-8904cb805353"
 Seis = "dd80f4d8-c2f6-58bd-9bd3-4635f134261d"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[weakdeps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+
+[extensions]
+TraceArraysMakieExt = "Makie"
+
 [compat]
 FFTW = "1"
+Makie = "0.20, 0.21, 0.22, 0.23, 0.24"
 julia = "1.10"
 
 [extras]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ DocMeta.setdocmeta!(TraceArrays, :DocTestSetup, :(using TraceArrays); recursive=
 
 makedocs(;
     modules=[TraceArrays],
-    authors="Andy Nowacki <a.nowacki@leeds.ac.uk> and contributors",
+    authors="Andy Nowacki <a.nowacki@leeds.ac.uk>",
     repo="https://github.com/anowacki/TraceArrays.jl/blob/{commit}{path}#{line}",
     sitename="TraceArrays.jl",
     format=Documenter.HTML(;

--- a/ext/TraceArraysMakieExt.jl
+++ b/ext/TraceArraysMakieExt.jl
@@ -1,0 +1,200 @@
+module TraceArraysMakieExt
+
+import Seis
+import TraceArrays
+
+@static if isdefined(Base, :get_extension)
+    import Makie
+else
+    import ..Makie
+end
+#=
+    Record sections
+=#
+function Seis.plot_section!(
+    ax::Makie.Axis,
+    t::TraceArrays.AbstractTraceArray,
+    y_values=nothing,
+    args...;
+    kwargs...
+)
+    yvalues, _ = _get_y_values_and_label(t, y_values)
+    Seis.plot_section!(ax, collect(t), yvalues, args...; kwargs...)
+end
+function Seis.plot_section!(
+    t::TraceArrays.AbstractTraceArray,
+    y_values=nothing,
+    args...;
+    kwargs...
+)
+    yvalues, _ = _get_y_values_and_label(t, y_values)
+    Seis.plot_section!(Makie.current_axis(), collect(t), yvalues, args...; kwargs...)
+end
+
+function Seis.plot_section(
+    t::TraceArrays.AbstractTraceArray,
+    y_values=nothing,
+    args...;
+    axis=(),
+    kwargs...
+)
+    yvalues, ylabel = _get_y_values_and_label(t, y_values)
+    Seis.plot_section(collect(t), yvalues, args...; axis=(; ylabel, axis...), kwargs...)
+end
+function Seis.plot_section(
+    gp::Union{Makie.GridPosition,Makie.GridSubposition},
+    t::TraceArrays.AbstractTraceArray,
+    y_values=nothing,
+    args...;
+    axis=(),
+    kwargs...
+)
+    yvalues, ylabel = _get_y_values_and_label(t, y_values)
+    Seis.plot_section(gp, collect(t), yvalues, args...; axis=(; ylabel, axis...), kwargs...)
+end
+
+#=
+    Heatmaps: time domain
+=#
+function TraceArrays.plot_heatmap!(
+    ax::Makie.Axis,
+    t::TraceArrays.AbstractTraceArray,
+    y_values=nothing;
+    kwargs...
+)
+    yvalues, _ = _get_y_values_and_label(t, y_values)
+    Makie.heatmap!(ax, Seis.times(t), yvalues, Seis.trace(t); kwargs...)
+end
+
+function TraceArrays.plot_heatmap(
+    gp::Union{Makie.GridPosition,Makie.GridSubposition},
+    t::TraceArrays.AbstractTraceArray,
+    y_values=nothing;
+    axis=(),
+    kwargs...
+)
+    yvalues, ylabel = _get_y_values_and_label(t, y_values)
+    Makie.heatmap(gp, Seis.times(t), yvalues, Seis.trace(t);
+        axis=(xlabel="Time / s", ylabel, axis...),
+        kwargs...
+    )
+end
+
+function TraceArrays.plot_heatmap(
+    t::TraceArrays.AbstractTraceArray,
+    y_values=nothing;
+    figure=(),
+    axis=(),
+    kwargs...
+)
+    fig = Makie.Figure(; figure...)
+    ax, hm = TraceArrays.plot_heatmap(fig[1,1], t, y_values; axis, kwargs...)
+    Makie.FigureAxisPlot(fig, ax, hm)
+end
+
+#=
+    Heatmaps: frequency-wavenumber domain
+=#
+function TraceArrays.plot_heatmap!(
+    ax::Makie.Axis,
+    t::TraceArrays.FourierDASArray;
+    kwargs...
+)
+    Makie.heatmap!(ax, TraceArrays.wavenumbers(t), Seis.frequencies(t), abs.(Seis.trace(t))'; kwargs...)
+end
+
+function TraceArrays.plot_heatmap(
+    gp::Union{Makie.GridPosition,Makie.GridSubposition},
+    t::TraceArrays.FourierDASArray;
+    axis=(),
+    kwargs...
+)
+    Makie.heatmap(
+        gp, TraceArrays.wavenumbers(t), Seis.frequencies(t), abs.(Seis.trace(t))';
+        axis=(xlabel="Wavenumber / m⁻¹", ylabel="Frequency / Hz", axis...),
+        kwargs...
+    )
+end
+
+function TraceArrays.plot_heatmap(
+    t::TraceArrays.FourierDASArray;
+    figure=(),
+    axis=(),
+    kwargs...
+)
+    fig = Makie.Figure(; figure...)
+    ax, hm = TraceArrays.plot_heatmap(fig[1,1], t; axis, kwargs...)
+    Makie.FigureAxisPlot(fig, ax, hm)
+end
+
+# Add methods for Makie.heatmap[!] for time- and frequency-domain trace arrays
+for AT in (TraceArrays.AbstractTraceArray, TraceArrays.AbstractFourierTraceArray)
+    @eval begin
+        Makie.heatmap(
+            gp::Union{Makie.GridPosition,Makie.GridSubposition},
+            t::$AT,
+            args...;
+            kwargs...
+        ) = TraceArrays.plot_heatmap(gp, t, args...; kwargs...)
+        Makie.heatmap(
+            t::$AT,
+            args...;
+            kwargs...
+        ) = TraceArrays.plot_heatmap(t, args...; kwargs...)
+        Makie.heatmap!(
+            ax::Makie.Axis,
+            t::$AT,
+            args...;
+            kwargs...
+        ) = TraceArrays.plot_heatmap!(ax, t, args...; kwargs...)
+    end
+end
+
+#=
+    Helpers
+=#
+"Return the y-coordinates at which to plot the traces and the axis label"
+function _get_y_values_and_label(t::TraceArrays.AbstractTraceArray, y_values)
+    if isnothing(y_values)
+        _default_y_values_and_label(t)
+    elseif y_values isa AbstractArray
+        length(y_values) == length(t) ||
+            throw(ArgumentError(
+                "length of y values ($(length(y_values))) does not " *
+                "match number of traces ($(length(t)))"
+            ))
+        y_values, ""
+    elseif y_values == TraceArrays.distances
+        y_values(t), "Distance / m"
+    elseif y_values == Seis.distance_deg
+        y_values.(t.evt, t.sta), "Epicentral distance / °"
+    elseif y_values == Seis.distance_km
+        y_values.(t.evt, t.sta), "Epicentral distance / km"
+    elseif y_values isa Function
+        y_values(t), ""
+    elseif y_values isa Symbol
+        getproperty.(t.meta, y_values), String(y_values)
+    elseif y_values isa AbstractString
+        if y_values == "index"
+            1:length(t), "Trace index"
+        else
+            throw(ArgumentError("unrecognised y axis name '$y_values'"))
+        end
+    else
+        throw(ArgumentError("unknown y_values value"))
+    end
+end
+
+"The default y-coordinates and axis label for kinds of AbstractTraceArrays"
+_default_y_values_and_label(t::TraceArrays.AbstractTraceArray) = 1:length(t), "Trace index"
+function _default_y_values_and_label(t::TraceArrays.DASArray)
+    ys = TraceArrays.distances(t)
+    # Use km if range too large
+    if abs(-(extrema(ys)...)) > 1000
+        ys./1000, "Cable distance / km"
+    else
+        ys, "Cable distance / m"
+    end
+end
+
+end # module

--- a/src/TraceArrays.jl
+++ b/src/TraceArrays.jl
@@ -20,6 +20,9 @@ export
     integrate_distance,
     remove_median_trace!,
     remove_median_trace,
+    # Plotting
+    plot_heatmap,
+    plot_heatmap!,
     # Reexported Seis things
     AbstractTrace,
     Event,
@@ -40,6 +43,8 @@ export
     normalise,
     normalise!,
     nsamples,
+    plot_section,
+    plot_section!,
     remove_trend,
     remove_trend!,
     starttime,
@@ -71,6 +76,8 @@ import Seis: AbstractTrace,
     normalise,
     normalise!,
     nsamples,
+    plot_section,
+    plot_section!,
     remove_trend,
     remove_trend!,
     starttime,
@@ -90,5 +97,7 @@ include("show.jl")
 # Methods
 include("filtering.jl")
 include("operations.jl")
+# Package extensions
+include("makie.jl")
 
 end

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -1,0 +1,44 @@
+"""
+    plot_heatmap([gridposition,] t::DASArray; figure=(), axis(), kwargs...)
+    plot_heatmap([gridposition,] t::FourierDASArray; figure=(), axis(), kwargs...)
+
+Plot the trace values of a `DASArray`, or the absolute values of
+a `FourierDASArray`'s coefficients, in terms of frequency and wavenumber
+on via `Makie.heatmap`.
+
+If the first argument is a grid position (`Makie.GridPosition` or
+`Makie.GridSubposition`), then a new axis is created at that point within
+the layout.  Keyword arguments to the `Makie.Axis` constructor can be
+passed as a named tuple in `axis`.  This method returns a `Makie.AxisPlot`
+which can be iterated to retrieve the axis handle and plot handle.
+
+Without a grid position, a new figure
+is created, in which case the `figure` keyword argument can be used to
+pass a named tuple of keyword arguments to the `Makie.Figure` constructor.
+This method returns a `Makie.FigureAxisPlot` containing handles to all
+three of the figure, axis and plot object.
+
+Remaining keyword arguments `kwargs` are passed to the call to
+`Makie.heatmap`.
+
+This function can only be used after loading a
+[Makie](https://docs.makie.org/stable/)
+[backend](https://docs.makie.org/stable/explanations/backends/backends),
+e.g. by doing `using GLMakie`, `using CairoMakie`, and so on.
+"""
+function plot_heatmap end
+
+"""
+    plot_heatmap!(axis::Makie.Axis, t::FourierDASArray; kwargs...)
+
+Plot the trace values of a `DASArray`, or the absolute values of
+a `FourierDASArray`'s coefficients, in terms of frequency and wavenumber
+on via `Makie.heatmap`.  The plot is added to an existing `Makie.Axis`
+`axis`.  `kwargs` are passed to `Makie.heatmap`.
+
+This function can only be used after loading a
+[Makie](https://docs.makie.org/stable/)
+[backend](https://docs.makie.org/stable/explanations/backends/backends),
+e.g. by doing `using GLMakie`, `using CairoMakie`, and so on.
+"""
+function plot_heatmap! end


### PR DESCRIPTION
Firstly, add the functions `plot_heatmap` and `plot_heatmap!` to plot
`DASArray`s and `FourierDASArray`s as heatmaps.  At the same time,
add methods to `Makie.heatmap[!]` to call these functions for the
appropriate arguments.

Secondly, add methods to `Seis.plot_section` to plot trace arrays as
record sections and automatically pick the most appropriate values on
the y-axis at which to plot traces.

Notably, there are no tests for this plotting functionality; perhaps it
should be added in a separate workflow run or be guarded by an
environment variable so that tests can be run without plotting for the
most part.
